### PR TITLE
[Tests] migrate tests to Github Actions

### DIFF
--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -1,0 +1,54 @@
+name: 'Tests: node.js'
+
+on: [pull_request, push]
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.set-matrix.outputs.requireds }}
+      minors: ${{ steps.set-matrix.outputs.optionals }}
+    steps:
+      - uses: ljharb/actions/node/matrix@main
+        id: set-matrix
+        with:
+          preset: '>=4'
+
+  latest:
+    needs: [matrix]
+    name: 'latest minors'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.latest) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run tests-only'
+        with:
+          node-version: ${{ matrix.node-version }}
+          command: 'tests-only'
+  minors:
+    needs: [matrix, latest]
+    name: 'non-latest minors'
+    continue-on-error: true
+    if: ${{ !github.head_ref || !startsWith(github.head_ref, 'renovate') }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.minors) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        with:
+          node-version: ${{ matrix.node-version }}
+          command: 'tests-only'
+
+  node:
+    name: 'node 4+'
+    needs: [latest, minors]
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo tests completed'

--- a/.github/workflows/node-iojs.yml
+++ b/.github/workflows/node-iojs.yml
@@ -1,0 +1,58 @@
+name: 'Tests: node.js (io.js)'
+
+on: [pull_request, push]
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      latest: ${{ steps.set-matrix.outputs.requireds }}
+      minors: ${{ steps.set-matrix.outputs.optionals }}
+    steps:
+      - uses: ljharb/actions/node/matrix@main
+        id: set-matrix
+        with:
+          preset: 'iojs'
+
+  latest:
+    needs: [matrix]
+    name: 'latest minors'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.latest) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run tests-only'
+        with:
+          node-version: ${{ matrix.node-version }}
+          command: 'tests-only'
+          skip-ls-check: true
+
+  minors:
+    needs: [matrix, latest]
+    name: 'non-latest minors'
+    continue-on-error: true
+    if: ${{ !github.head_ref || !startsWith(github.head_ref, 'renovate') }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.minors) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run tests-only'
+        with:
+          node-version: ${{ matrix.node-version }}
+          command: 'tests-only'
+          skip-ls-check: true
+
+  node:
+    name: 'io.js'
+    needs: [latest, minors]
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo tests completed'

--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -1,0 +1,26 @@
+name: 'Tests: pretest/posttest'
+
+on: [pull_request, push]
+
+jobs:
+  pretest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run pretest'
+        with:
+          node-version: 'lts/*'
+          command: 'pretest'
+
+  posttest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        name: 'npm install && npm run posttest'
+        with:
+          node-version: 'lts/*'
+          command: 'posttest'

--- a/.github/workflows/node-zero.yml
+++ b/.github/workflows/node-zero.yml
@@ -1,0 +1,58 @@
+name: 'Tests: node.js (0.x)'
+
+on: [pull_request, push]
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      stable: ${{ steps.set-matrix.outputs.requireds }}
+      unstable: ${{ steps.set-matrix.outputs.optionals }}
+    steps:
+      - uses: ljharb/actions/node/matrix@main
+        id: set-matrix
+        with:
+          preset: '0.x'
+
+  stable:
+    needs: [matrix]
+    name: 'stable minors'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.stable) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        with:
+          node-version: ${{ matrix.node-version }}
+          command: 'tests-only'
+          cache-node-modules-key: node_modules-${{ github.workflow }}-${{ github.action }}-${{ github.run_id }}
+          skip-ls-check: true
+
+  unstable:
+    needs: [matrix, stable]
+    name: 'unstable minors'
+    continue-on-error: true
+    if: ${{ !github.head_ref || !startsWith(github.head_ref, 'renovate') }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix: ${{ fromJson(needs.matrix.outputs.unstable) }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ljharb/actions/node/run@main
+        with:
+          node-version: ${{ matrix.node-version }}
+          command: 'tests-only'
+          cache-node-modules-key: node_modules-${{ github.workflow }}-${{ github.action }}-${{ github.run_id }}
+          skip-ls-check: true
+
+  node:
+    name: 'node 0.x'
+    needs: [stable, unstable]
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo tests completed'

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,13 @@
+{
+	"all": true,
+	"check-coverage": false,
+	"reporter": ["text-summary", "text", "html", "json"],
+	"lines": 86,
+	"statements": 85.93,
+	"functions": 82.43,
+	"branches": 76.06,
+	"exclude": [
+		"coverage",
+		"test"
+	]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-version: ~> 1.0
-language: node_js
-os:
- - linux
-import:
- - ljharb/travis-ci:node/all.yml
- - ljharb/travis-ci:node/pretest.yml
- - ljharb/travis-ci:node/posttest.yml

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"pretest": "npm run lint",
 		"prelint": "evalmd README.md",
 		"lint": "eslint .",
-		"tests-only": "tape 'test/**'",
+		"tests-only": "nyc tape 'test/**'",
 		"test": "npm run tests-only",
 		"posttest": "npx aud --production",
 		"version": "auto-changelog && git add CHANGELOG.md",
@@ -67,6 +67,7 @@
 		"functions-have-names": "^1.2.1",
 		"has-strict-mode": "^1.0.0",
 		"iterate-iterator": "^1.0.1",
+		"nyc": "^10.3.2",
 		"safe-publish-latest": "^1.1.4",
 		"tape": "^5.0.0-next.5"
 	},


### PR DESCRIPTION
Per https://github.com/ljharb/object.assign/pull/81
> travis-ci's new pricing plan, and its defaults, have caused all my `ljharb` repos to have zero CI whatsoever until December. @travis-ci Support is MIA, so I unfortunately can't rely on it as a service anymore.